### PR TITLE
Update links for v0.6.0-rc.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 # If you want information on how to edit this file checkout,
 # http://makefiletutorial.com/
 
-BASE_VERSION = 0.0.0-dev
+BASE_VERSION = 0.6.0-rc.1
 SHORT_SHA = $(shell git rev-parse --short=7 HEAD | tr -d [:punct:])
 VERSION_SUFFIX = $(SHORT_SHA)
 BRANCH_NAME = $(shell git rev-parse --abbrev-ref HEAD | tr -d [:punct:])
@@ -225,7 +225,7 @@ site/static/swaggerui/:
 	cp -rf $(TOOLCHAIN_DIR)/swaggerui-temp/swagger-ui-$(SWAGGERUI_VERSION)/dist/ \
 		$(SITE_DIR)/static/swaggerui
 	# Update the Swagger doc URLs to point to the same version as 
-	curl -L -o $(SITE_DIR)/static/swaggerui/config.json https://raw.githubusercontent.com/googleforgames/open-match/$(OPEN_MATCH_REMOTE_BRANCH)/cmd/swaggerui/config.json
+	curl -L -o $(SITE_DIR)/static/swaggerui/config.json https://raw.githubusercontent.com/googleforgames/open-match/$(OPEN_MATCH_REMOTE_BRANCH)/third_party/swaggerui/config.json
 	$(SED_REPLACE) 's|url:.*|configUrl: "config.json",|g' $(SITE_DIR)/static/swaggerui/index.html
 	rm -rf $(TOOLCHAIN_DIR)/swaggerui-temp
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -113,7 +113,7 @@ steps:
     path: '/go'
 
 substitutions:
-    _OM_VERSION: "0.0.0-dev"
+    _OM_VERSION: "0.6.0-rc.1"
     _GCB_POST_SUBMIT: "0"
     _GCB_LATEST_VERSION: "undefined"
 logsBucket: 'gs://open-match-site-build-logs/'

--- a/site/config.toml
+++ b/site/config.toml
@@ -73,7 +73,7 @@ github_repo = "https://github.com/googleforgames/open-match"
 gcs_engine_id = "008748710159674449076:sqoelpnrdoe"
 
 release_branch = "master"
-release_version = "0.0.0-dev"
+release_version = "0.6.0-rc.1"
 
 # User interface configuration
 [params.ui]

--- a/site/static/swaggerui/config.json
+++ b/site/static/swaggerui/config.json
@@ -1,10 +1,10 @@
 {
     "urls": [
-        {"name": "Frontend", "url": "https://open-match.dev/api/v0.0.0-dev/frontend.swagger.json"},
-        {"name": "Backend", "url": "https://open-match.dev/api/v0.0.0-dev/backend.swagger.json"},
-        {"name": "Mmlogic", "url": "https://open-match.dev/api/v0.0.0-dev/mmlogic.swagger.json"},
-        {"name": "MatchFunction", "url": "https://open-match.dev/api/v0.0.0-dev/matchfunction.swagger.json"},
-        {"name": "Synchronizer", "url": "https://open-match.dev/api/v0.0.0-dev/synchronizer.swagger.json"},
-        {"name": "Evaluator", "url": "https://open-match.dev/api/v0.0.0-dev/evaluator.swagger.json"}
+        {"name": "Frontend", "url": "https://open-match.dev/api/v0.6.0-rc.1/frontend.swagger.json"},
+        {"name": "Backend", "url": "https://open-match.dev/api/v0.6.0-rc.1/backend.swagger.json"},
+        {"name": "Mmlogic", "url": "https://open-match.dev/api/v0.6.0-rc.1/mmlogic.swagger.json"},
+        {"name": "MatchFunction", "url": "https://open-match.dev/api/v0.6.0-rc.1/matchfunction.swagger.json"},
+        {"name": "Synchronizer", "url": "https://open-match.dev/api/v0.6.0-rc.1/synchronizer.swagger.json"},
+        {"name": "Evaluator", "url": "https://open-match.dev/api/v0.6.0-rc.1/evaluator.swagger.json"}
     ]
 }


### PR DESCRIPTION
Update the website links to point to 0.6* artifacts instead of the 0.0.0-dev artifacts.