### PR TITLE
Fix broken edit links and remove target=_blank (#13)

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -37,7 +37,7 @@ blog = "/:section/:year/:month/:day/:slug/"
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]
 plainIDAnchors = true
-hrefTargetBlank = true
+hrefTargetBlank = false
 angledQuotes = false
 latexDashes = true
 
@@ -67,7 +67,7 @@ weight = 1
 [params]
 copyright = "Copyright Google LLC. All Rights Reserved"
 privacy_policy = "https://policies.google.com/privacy"
-github_repo = "https://github.com/googleforgames/open-match"
+github_repo = "https://github.com/googleforgames/open-match-docs"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "008748710159674449076:sqoelpnrdoe"


### PR DESCRIPTION
This fixes the edit page links and in page links will no longer create new tabs.