### PR TITLE
Fix broken edit links and remove target=_blank (release-0.6 branch) (#13)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ site/static/swaggerui/:
 	cp -rf $(TOOLCHAIN_DIR)/swaggerui-temp/swagger-ui-$(SWAGGERUI_VERSION)/dist/ \
 		$(SITE_DIR)/static/swaggerui
 	# Update the Swagger doc URLs to point to the same version as 
-	curl -L -o $(SITE_DIR)/static/swaggerui/config.json https://raw.githubusercontent.com/googleforgames/open-match/$(OPEN_MATCH_REMOTE_BRANCH)/cmd/swaggerui/config.json
+	curl -L -o $(SITE_DIR)/static/swaggerui/config.json https://raw.githubusercontent.com/googleforgames/open-match/$(OPEN_MATCH_REMOTE_BRANCH)/third_party/swaggerui/config.json
 	$(SED_REPLACE) 's|url:.*|configUrl: "config.json",|g' $(SITE_DIR)/static/swaggerui/index.html
 	rm -rf $(TOOLCHAIN_DIR)/swaggerui-temp
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -37,7 +37,7 @@ blog = "/:section/:year/:month/:day/:slug/"
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]
 plainIDAnchors = true
-hrefTargetBlank = true
+hrefTargetBlank = false
 angledQuotes = false
 latexDashes = true
 
@@ -67,7 +67,7 @@ weight = 1
 [params]
 copyright = "Copyright Google LLC. All Rights Reserved"
 privacy_policy = "https://policies.google.com/privacy"
-github_repo = "https://github.com/googleforgames/open-match"
+github_repo = "https://github.com/googleforgames/open-match-docs"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "008748710159674449076:sqoelpnrdoe"


### PR DESCRIPTION
This fixes the edit page links and in page links will no longer create new tabs.

Fixes #13 