### PR TITLE
Clarify install-demo requirement

### DIFF
--- a/site/content/en/docs/Getting Started/first_match.md
+++ b/site/content/en/docs/Getting Started/first_match.md
@@ -30,7 +30,7 @@ Here is a sequence diagram of Open Match matching two players.
 # Install Demo in a Kubernetes Cluster
 
 This demo has the following kubernetes deployments (with services and some other
-housekeeping). Note that the demo needs to be installed with the other Open Match components under the same cluster with the same namespace:
+housekeeping). Note that the demo needs to be installed in the same cluster and within the same namespace as other Open Match components.
 
 - Matchmaking function.
 - Evaluator, a piece of Open Match which can be customized, but isn't in this

--- a/site/content/en/docs/Getting Started/first_match.md
+++ b/site/content/en/docs/Getting Started/first_match.md
@@ -27,10 +27,10 @@ Here is a sequence diagram of Open Match matching two players.
 
 ![Demo Match Sequence Diagram](../../../images/demo-match-sequence.png)
 
-# Install Demo
+# Install Demo in a Kubernetes Cluster
 
 This demo has the following kubernetes deployments (with services and some other
-housekeeping):
+housekeeping). Note that the demo needs to be installed with the other Open Match components under the same cluster with the same namespace:
 
 - Matchmaking function.
 - Evaluator, a piece of Open Match which can be customized, but isn't in this


### PR DESCRIPTION
We only support having the demo installed under the same namespace as other Open Match components for now. Edited the `first match` page to clarify this restriction.