### PR TITLE
Verbose HTLM Test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ site-test: $(RENDERED_SITE_DIR_REL)/ $(HTMLTEST_REL)
 	rm -rf $(TEMP_SITE_DIR)
 	mkdir -p $(TEMP_SITE_DIR)/site/
 	cp -rf $(RENDERED_SITE_DIR)/public/* $(TEMP_SITE_DIR)/site/
-	$(HTMLTEST) --conf $(SITE_DIR)/htmltest.yaml $(TEMP_SITE_DIR)
+	$(HTMLTEST) -l 0 --conf $(SITE_DIR)/htmltest.yaml $(TEMP_SITE_DIR)
 
 browse-site: $(RENDERED_SITE_DIR_REL)/
 	cd $(RENDERED_SITE_DIR) && dev_appserver.py .app.yaml


### PR DESCRIPTION
Our current HTML test does not output any helpful information as seen in https://pantheon.corp.google.com/cloud-build/builds/5cf16700-ff37-4b20-94b0-9ffa09ca7c07;step=8?project=open-match-build. This commit changed the log output level to debug to make it more helpful when debugging CI failures