### PR TITLE
Uppercase "Assignment"

### DIFF
--- a/site/content/en/docs/Getting Started/_index.md
+++ b/site/content/en/docs/Getting Started/_index.md
@@ -31,7 +31,7 @@ Here are some of the Open Match concepts that you will encounter as you run the 
 Here are the components external to core Open Match that are implemented as a part of the demo:
 
 * **Match Function(MMF)**: The core matchmaking logic implemented as a service. It is invoked by Open Match to generate matches. It takes lists of tickets (which meet certain constraints) as input and returns any number of matches. For this basic demo, the Match Function simply pairs any two players into a Match.
-* **Director**: A component that requests Open Match for matches and then sets assignments on the Tickets in the matches found.
+* **Director**: A component that requests Open Match for matches and then sets Assignments on the Tickets in the matches found.
 
 Here is a sequence diagram of Open Match matching two players.
 
@@ -70,14 +70,14 @@ This emulates requests coming from players wanting to be matched. Each fake play
 
 - Sleeps to emulate a player on the main menu of the game before searching for a match.
 - Creates a ticket and sends the request to Open Match.
-- Waits to be given an assignment.
-- Sleeps to emulate playing a game connected to the given assignment.
+- Waits to be given an Assignment.
+- Sleeps to emulate playing a game connected to the given Assignment.
 
 ### Director
 
 [Source code](https://github.com/googleforgames/open-match/blob/{{< param release_branch >}}/examples/demo/components/director/director.go)
 
-This emulates the component that tells Open Match what kind of matches to find and gives found matches assignments. The steps it takes:
+This emulates the component that tells Open Match what kind of matches to find and gives found matches Assignments. The steps it takes:
 
 - Request Open Match to fetch matches from Tickets belonging to the specified pool. The Director does not specify any constraints for the Pool so all the currently searching tickets are considered.
 - For each match found, assign the Tickets in that match to a random IP address.  In a normal system, this would be asking a dedicated game server host (such as [Agones](https://agones.dev/site/)) for an IP of a game server instance.

--- a/site/content/en/docs/Guides/Matchmaker/_index.md
+++ b/site/content/en/docs/Guides/Matchmaker/_index.md
@@ -26,7 +26,7 @@ The Open Match Frontend provides management of Tickets (a basic matchmaking requ
 
 #### Open Match Backend
 
-The Open Match Backend provides the core functionality of generating matches. It accepts MatchProfiles (a match template that can be used to generate matches) and returns matches for the requested profile. It also enables setting assignments for matches.
+The Open Match Backend provides the core functionality of generating matches. It accepts MatchProfiles (a match template that can be used to generate matches) and returns matches for the requested profile. It also enables setting Assignments for matches.
 
 #### MMLogic (Data Service)
 
@@ -50,25 +50,25 @@ Although Open Match based Matchmaker offers core matchmaking functionality, some
 
 #### Game Frontend
 
-This is the component that receives the matchmaking request from the game client and eventually provides the game client with the assignment. The Game Frontend typically authenticates the player, fetches player data and creates a matchmaking request in Open Match and fetches the assignment for the Ticket.
+This is the component that receives the matchmaking request from the game client and eventually provides the game client with the Assignment. The Game Frontend typically authenticates the player, fetches player data and creates a matchmaking request in Open Match and fetches the Assignment for the Ticket.
 
 #### Director
 
-This is the component that understands the types of matches (MatchProfiles) that can be served and fetches matches from the Open Match Backend. The Director also interfaces with the DGS allocation system to fetch Game Servers for matches and sets Game Server assignments in Open Match.
+This is the component that understands the types of matches (MatchProfiles) that can be served and fetches matches from the Open Match Backend. The Director also interfaces with the DGS allocation system to fetch Game Servers for matches and sets Game Server Assignments in Open Match.
 
 ### Life of a matchmaking request
 
 Here is a high level flow for a matchmaking request.
 
-1. A Game Client connects to the Game Frontend requesting for a Game Server assignment.
+1. A Game Client connects to the Game Frontend requesting for a Game Server Assignment.
 2. The Game Frontend validates the player, fetches its properties from the platform services and calls Open Match Frontend to create a Ticket for this player.
 3. The Director calls FetchMatches on Open Match Backend to generate Matches for a MatchProfile.
 4. Open Match Backend triggers Match Function execution for this MatchProfile.
 5. The Match Function fetches all the Tickets for the the MatchProfile and generates a Match.
 6. The Open Match Backend returns the Match to the Director.
 7. The Director requests the DGS allocation system for a Game Server for the Match.
-8. The Director then sets an assignment for all the Tickets in the Match to the Game Server that was returned.
-9. The Game Frontend fetches the assignment and returns it back to the client.
+8. The Director then sets an Assignment for all the Tickets in the Match to the Game Server that was returned.
+9. The Game Frontend fetches the Assignment and returns it back to the client.
 
 ## Components Deep Dive
 

--- a/site/content/en/docs/Guides/Matchmaker/director.md
+++ b/site/content/en/docs/Guides/Matchmaker/director.md
@@ -8,7 +8,7 @@ description:
 
 ## Overview
 
-The Director fetches Matches from Open Match for a set of MatchProfiles. For these matches, it fetches Game Server from a DGS allocation system. It can then communicate the assignments back to the Game Frontend.
+The Director fetches Matches from Open Match for a set of MatchProfiles. For these matches, it fetches Game Server from a DGS allocation system. It can then communicate the Assignments back to the Game Frontend.
 
 ## Open Match Interactions
 
@@ -81,7 +81,7 @@ MatchProfile{
 
 ### Assigning Tickets
 
-Once a Match is generated, the Director can fetch a Game Server for this Match from the DGS (Dedicated Game Server) allocation system and then set that as an assignment on all the Tickets of this Match. Here is the API on Open Match Backend to do this:
+Once a Match is generated, the Director can fetch a Game Server for this Match from the DGS (Dedicated Game Server) allocation system and then set that as an Assignment on all the Tickets of this Match. Here is the API on Open Match Backend to do this:
 
 ```
 rpc AssignTickets(AssignTicketsRequest) returns (AssignTicketsResponse) {
@@ -91,11 +91,11 @@ rpc AssignTickets(AssignTicketsRequest) returns (AssignTicketsResponse) {
 };
 ```
 
-The API takes a list of TicketIDs to make the assignment and an assignment object.
+The API takes a list of TicketIDs to make the Assignment and an Assignment object.
 
 #### Assignment
 
-Here is the proto for the assignment:
+Here is the proto for the Assignment:
 
 ```
 message Assignment {
@@ -105,4 +105,4 @@ message Assignment {
 }
 ```
 
-It comprises of the connection string, any error that the user wants to pass through to on the assignment and a set of extension blobs that Open Match passes through.
+It comprises of the connection string, any error that the user wants to pass through to on the Assignment and a set of extension blobs that Open Match passes through.

--- a/site/content/en/docs/Guides/Matchmaker/frontend.md
+++ b/site/content/en/docs/Guides/Matchmaker/frontend.md
@@ -8,7 +8,7 @@ description:
 
 ## Overview
 
-The Game Frontend receives the matchmaking request from the Player's Game Client. It can authenticate the player and fetch the player data from some backend storage (or Platform Services if required). It submits the matchmaking request to Open Match by creating a Ticket. Once an assignment is set for this Ticket, the Game Frontend communicates the assignment back to the Game Client. Game Frontend may handle creating lobbies, groups, etc.
+The Game Frontend receives the matchmaking request from the Player's Game Client. It can authenticate the player and fetch the player data from some backend storage (or Platform Services if required). It submits the matchmaking request to Open Match by creating a Ticket. Once an Assignment is set for this Ticket, the Game Frontend communicates the Assignment back to the Game Client. Game Frontend may handle creating lobbies, groups, etc.
 
 ## Open Match Interactions
 
@@ -54,7 +54,7 @@ SearchFields: &pb.SearchFields{
 
 ### Fetching the Assignment
 
-The Game Frontend can get the current Ticket from Open Match and check if the Ticket has assignment information populated. Here is the API to get a Ticket:
+The Game Frontend can get the current Ticket from Open Match and check if the Ticket has Assignment information populated. Here is the API to get a Ticket:
 
 ```
 rpc GetTicket(GetTicketRequest) returns (Ticket) {
@@ -64,11 +64,11 @@ rpc GetTicket(GetTicketRequest) returns (Ticket) {
 }
 ```
 
-Note: Open Match does not guarantee persistent storage and hence should not be used as the authoritative source for Game Client assignment information. Once the assignment for a Ticket is fetched, the Game Frontent should (if necessary) persist this information in its own persistent storage for future lookup.
+Note: Open Match does not guarantee persistent storage and hence should not be used as the authoritative source for Game Client Assignment information. Once the Assignment for a Ticket is fetched, the Game Frontent should (if necessary) persist this information in its own persistent storage for future lookup.
 
 ### Deleting a Ticket
 
-Once the player assignment has been stored & communicated to the Game Client, the Game Frontend may delete the Ticket from Open Match. Here is the API exposed on Open Match Frontend to delete a Ticket:
+Once the player Assignment has been stored & communicated to the Game Client, the Game Frontend may delete the Ticket from Open Match. Here is the API exposed on Open Match Frontend to delete a Ticket:
 
 ```
 rpc DeleteTicket(DeleteTicketRequest) returns (DeleteTicketResponse) {

--- a/site/content/en/docs/Reference/api.md
+++ b/site/content/en/docs/Reference/api.md
@@ -196,7 +196,7 @@ FunctionConfig specifies a MMF address and client type for Backend to establish 
 <a name="openmatch.Backend"></a>
 
 ### Backend
-The Backent service implements APIs to generate matches and handle ticket assignments.
+The Backent service implements APIs to generate matches and handle ticket Assignments.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|

--- a/site/content/en/docs/Tutorials/Matchmaker101/_index.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/_index.md
@@ -67,8 +67,8 @@ The tutorial walks through building the Game Frontend, Director, Match Function 
 - The Game Frontend creates Tickets that specified a game mode.
 - The Director requests for matches for a specific game mode.
 - The Match Function queries for Tickets from the current pool that match this constraint and groups available Tickets into match proposals.
-- The Director receives the matches and sets fake assignments for Tickets in these.
-- The Game Frontend receives these assignments and then deletes the Tickets.
+- The Director receives the matches and sets fake Assignments for Tickets in these.
+- The Game Frontend receives these Assignments and then deletes the Tickets.
 
 **A complete solution for this tutorial can be found at ```tutorials/matchmaker101```. To use the solution directly, just run the "Build and Push" step in each of the component sections and then go to [Deploy and Run]({{< relref "./deploy.md" >}})**
 

--- a/site/content/en/docs/Tutorials/Matchmaker101/director.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/director.md
@@ -47,7 +47,7 @@ func generateProfiles() []*pb.MatchProfile {
 }
 ```
 
-Please copy the above helper or add your own profile generation logic to ```$TUTORIALROOT/director/profiles.go```. Also, you may tweak the profile polling interval, assignment logic, etc. in ```$TUTORIALROOT/director/main.go```.
+Please copy the above helper or add your own profile generation logic to ```$TUTORIALROOT/director/profiles.go```. Also, you may tweak the profile polling interval, Assignment logic, etc. in ```$TUTORIALROOT/director/main.go```.
 
 ### Configuring
 

--- a/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
@@ -10,9 +10,9 @@ The Game Frontend serves as a layer that transfers players' matchmaking requests
 
 - Fetches the player data from some backend storage (or Platform Services if required) and authenticates players.
 - Submits the matchmaking requests to Open Match by creating a Ticket.
-- Communicates the assignment result back to the Game Client once Open Match found an assignment for this Ticket.
+- Communicates the Assignment result back to the Game Client once Open Match found an Assignment for this Ticket.
 
-This tutorial provides a very basic Game Frontend scaffold (```$TUTORIALROOT/frontend```) that periodically generates batches of fake Tickets, adds them to Open Match, and polls these Tickets for Assignment. Once an Assignment is received it emits a log with the Assignment details (as a proxy for returning the assignment to the Player) and deletes the Ticket from Open Match.
+This tutorial provides a very basic Game Frontend scaffold (```$TUTORIALROOT/frontend```) that periodically generates batches of fake Tickets, adds them to Open Match, and polls these Tickets for Assignment. Once an Assignment is received it emits a log with the Assignment details (as a proxy for returning the Assignment to the Player) and deletes the Ticket from Open Match.
 
 **Note:** Under production environment, polling each Ticket for Assignment is not recommended. We recommend using event handlers/listeners to communicate Assignments result to the Game Frontend.
 


### PR DESCRIPTION
Ticket, Backend, MMLogic is all uppercased - becasue they are special nouns and concept in this system. Assignment is the same, as we should upper case it when we mean a Open Match Assignment, rather than a colloquial assignment of a different variety.

I personally found it tricky to remember it was a core concept otherwise.