### PR TITLE
add a reminder to run prerequisites before installing demo

### DIFF
--- a/site/content/en/docs/Getting Started/_index.md
+++ b/site/content/en/docs/Getting Started/_index.md
@@ -36,6 +36,8 @@ Here is a sequence diagram of Open Match matching two players.
 ![Demo Match Sequence Diagram](../../images/demo-match-sequence.png)
 
 ## Install the Demo
+| *Be sure you have run through the prerequisites above before installing the demo.* |
+| --- |
 
 This step deploys a Match Function and the core demo application in under the `open-match-demo` namespace:
 


### PR DESCRIPTION
Since it tripped me up, I propose adding text at the top of the "Installing the Demo" section reminding the user to run the prerequisites before installing the demo.