### PR TITLE
Improve tutorial instructions for Minikube users

### DIFF
--- a/site/content/en/docs/Tutorials/Matchmaker101/deploy.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/deploy.md
@@ -10,8 +10,17 @@ This step assumes that you have completed the Tutorial prerequisites and all pri
 
 The next step is to deploy the Match Function, the Game Frontend and the Director to the same cluster as Open Match deployment but to a different namespace. The `$TUTORIALROOT/matchmaker.yaml` deploys these components to a `mm101-tutorial` namespace. Run the below command in the `$TUTORIALROOT` path to apply this YAML:
 
+- For GKE users, run:
 ```
 sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchmaker.yaml | kubectl apply -f -
+```
+
+- For Minikube users, run:
+```
+# Instructs Minikube to use local images
+# https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon
+eval $(minikube docker-env)
+sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchmaker.yaml | sed "s|Always|Never|g" | kubectl apply -f -
 ```
 
 ## Matchmaking ever after

--- a/site/content/en/docs/Tutorials/_index.md
+++ b/site/content/en/docs/Tutorials/_index.md
@@ -5,3 +5,12 @@ weight: 5
 description: >
   Open Match Tutorials
 ---
+
+{{% alert title="Note" color="info" %}}
+For Minikube users, please run the command below to instruct Minikube to use local Docker images.
+```bash
+# Instructs Minikube to use local images
+# https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon
+eval $(minikube docker-env)
+```
+{{% /alert %}}

--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -14,5 +14,5 @@ These pages show you how to get up and running as quickly as possible in Open Ma
 
 If you are new to Open Match, start with [Installation]({{< relref "./installation/_index.md" >}}), to get Open Match up and running. Then follow the [Getting Started Guide]({{< relref "./Getting Started/_index.md">}}) to see Open Match running in action.
 
-The [Tutorials]({{< relref "./Tutorials/_index.md" >}}) section walks you through how to implement your customized matchmaking logic and integrate it with Open Match
+The [Tutorials]({{< relref "./Tutorials/_index.md" >}}) section walks you through how to implement your customized matchmaking logic and integrate it with Open Match.
 <br/>


### PR DESCRIPTION
This is the same PR as #127.

Minikube users need to configure their docker to talk to the local docker daemon so that kubectl can find and pull the images. This commit added a note in the tutorials section for Minikube users to configure their docker environment correctly.