### PR TITLE
Remove dots from tutorial build and push steps

### DIFF
--- a/site/content/en/docs/Tutorials/CustomEvaluator/_index.md
+++ b/site/content/en/docs/Tutorials/CustomEvaluator/_index.md
@@ -112,7 +112,7 @@ As a reference, you may check the implementation of the [tutorial solution Evalu
 Now that we have a custom Evaluator, please run the below commands in the `$TUTORIALROOT` to build and push the Evaluator to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/custom-eval-tutorial-evaluator evaluator/.
+docker build -t $REGISTRY/custom-eval-tutorial-evaluator evaluator/
 docker push $REGISTRY/custom-eval-tutorial-evaluator
 ```
 
@@ -137,11 +137,11 @@ kubectl apply -f customization.yaml --namespace open-match
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/custom-eval-tutorial-frontend frontend/.
+docker build -t $REGISTRY/custom-eval-tutorial-frontend frontend/
 docker push $REGISTRY/custom-eval-tutorial-frontend
-docker build -t $REGISTRY/custom-eval-tutorial-director director/.
+docker build -t $REGISTRY/custom-eval-tutorial-director director/
 docker push $REGISTRY/custom-eval-tutorial-director
-docker build -t $REGISTRY/custom-eval-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/custom-eval-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/custom-eval-tutorial-matchfunction
 ```
 

--- a/site/content/en/docs/Tutorials/DefaultEvaluator/_index.md
+++ b/site/content/en/docs/Tutorials/DefaultEvaluator/_index.md
@@ -177,11 +177,11 @@ Add the above snippet to the MatchFunction and populate the logic for score calc
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/default-eval-tutorial-frontend frontend/.
+docker build -t $REGISTRY/default-eval-tutorial-frontend frontend/
 docker push $REGISTRY/default-eval-tutorial-frontend
-docker build -t $REGISTRY/default-eval-tutorial-director director/.
+docker build -t $REGISTRY/default-eval-tutorial-director director/
 docker push $REGISTRY/default-eval-tutorial-director
-docker build -t $REGISTRY/default-eval-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/default-eval-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/default-eval-tutorial-matchfunction
 ```
 

--- a/site/content/en/docs/Tutorials/Matchmaker101/director.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/director.md
@@ -65,7 +65,7 @@ Now that you have customized the Director, please run the below commands from `$
 
 ```
 # Build the Director image.
-docker build -t $REGISTRY/mm101-tutorial-director director/.
+docker build -t $REGISTRY/mm101-tutorial-director director/
 
 # Push the Director image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-director

--- a/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
@@ -56,7 +56,7 @@ Now that you have customized the Game Frontend, please run the below commands fr
 
 ```
 # Build the Frontend image.
-docker build -t $REGISTRY/mm101-tutorial-frontend frontend/.
+docker build -t $REGISTRY/mm101-tutorial-frontend frontend/
 
 # Push the Frontend image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-frontend

--- a/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
@@ -76,7 +76,7 @@ Now that you have customized the MatchFunction, please run the below commands fr
 
 ```
 # Build the MatchFunction image.
-docker build -t $REGISTRY/mm101-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/mm101-tutorial-matchfunction matchfunction/
 
 # Push the MatchFunction image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-matchfunction

--- a/site/content/en/docs/Tutorials/Matchmaker102/_index.md
+++ b/site/content/en/docs/Tutorials/Matchmaker102/_index.md
@@ -151,11 +151,11 @@ Although no changes are needed to the core matchmaking logic, you may add some l
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/mm102-tutorial-frontend frontend/.
+docker build -t $REGISTRY/mm102-tutorial-frontend frontend/
 docker push $REGISTRY/mm102-tutorial-frontend
-docker build -t $REGISTRY/mm102-tutorial-director director/.
+docker build -t $REGISTRY/mm102-tutorial-director director/
 docker push $REGISTRY/mm102-tutorial-director
-docker build -t $REGISTRY/mm102-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/mm102-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/mm102-tutorial-matchfunction
 ```
 


### PR DESCRIPTION
This commit removed the dot from the docker build command to slightly improve the tutorial experience. `docker build frontend/.` works but new users may accidentally typed `docker build frontend/ .` instead (and in some browsers the dot appears as the latter one.