### PR TITLE
Update Minikube installation guide for better experience

### DIFF
--- a/site/content/en/docs/Tutorials/CustomEvaluator/_index.md
+++ b/site/content/en/docs/Tutorials/CustomEvaluator/_index.md
@@ -39,6 +39,12 @@ If using GKE, you can populate the image registry using the command below:
 REGISTRY=gcr.io/$(gcloud config list --format 'value(core.project)')
 ```
 
+If using Minikube, please run the command below to instruct Minikube to [use local Docker images](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon):
+```bash
+eval $(minikube docker-env)
+```
+
+
 ### Get the tutorial template
 
 Make a local copy of the [tutorials Folder](https://github.com/googleforgames/open-match/blob/{{< param release_branch >}}/tutorials/custom_evaluator). Use `tutorials/custom_evaluator` as a working copy for all the instructions in this tutorial.
@@ -112,7 +118,7 @@ As a reference, you may check the implementation of the [tutorial solution Evalu
 Now that we have a custom Evaluator, please run the below commands in the `$TUTORIALROOT` to build and push the Evaluator to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/custom-eval-tutorial-evaluator evaluator/.
+docker build -t $REGISTRY/custom-eval-tutorial-evaluator evaluator/
 docker push $REGISTRY/custom-eval-tutorial-evaluator
 ```
 
@@ -137,11 +143,11 @@ kubectl apply -f customization.yaml --namespace open-match
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/custom-eval-tutorial-frontend frontend/.
+docker build -t $REGISTRY/custom-eval-tutorial-frontend frontend/
 docker push $REGISTRY/custom-eval-tutorial-frontend
-docker build -t $REGISTRY/custom-eval-tutorial-director director/.
+docker build -t $REGISTRY/custom-eval-tutorial-director director/
 docker push $REGISTRY/custom-eval-tutorial-director
-docker build -t $REGISTRY/custom-eval-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/custom-eval-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/custom-eval-tutorial-matchfunction
 ```
 

--- a/site/content/en/docs/Tutorials/DefaultEvaluator/_index.md
+++ b/site/content/en/docs/Tutorials/DefaultEvaluator/_index.md
@@ -31,6 +31,11 @@ If using GKE, you can populate the image registry using the command below:
 REGISTRY=gcr.io/$(gcloud config list --format 'value(core.project)')
 ```
 
+If using Minikube, please run the command below to instruct Minikube to [use local Docker images](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon):
+```bash
+eval $(minikube docker-env)
+```
+
 ### Get the tutorial template
 
 Make a local copy of the [tutorials Folder](https://github.com/googleforgames/open-match/blob/{{< param release_branch >}}/tutorials/default_evaluator). Use `tutorials/default_evaluator` as a working copy for all the instructions in this tutorial.
@@ -177,11 +182,11 @@ Add the above snippet to the MatchFunction and populate the logic for score calc
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/default-eval-tutorial-frontend frontend/.
+docker build -t $REGISTRY/default-eval-tutorial-frontend frontend/
 docker push $REGISTRY/default-eval-tutorial-frontend
-docker build -t $REGISTRY/default-eval-tutorial-director director/.
+docker build -t $REGISTRY/default-eval-tutorial-director director/
 docker push $REGISTRY/default-eval-tutorial-director
-docker build -t $REGISTRY/default-eval-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/default-eval-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/default-eval-tutorial-matchfunction
 ```
 

--- a/site/content/en/docs/Tutorials/Matchmaker101/_index.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/_index.md
@@ -30,14 +30,19 @@ If you already installed Open Match for the [Getting Started Demo]({{< relref ".
 
 Please setup an Image registry(such as [Docker Hub](https://hub.docker.com/) or [GC Container Registry](https://cloud.google.com/container-registry/)) to store the Docker Images used in this tutorial. Once you have set this up, here are the instructions to set up a shell variable that points to your registry:
 
-```
+```bash
 REGISTRY=[YOUR_REGISTRY_URL]
 ```
 
-If using GKE, the below command can be used to populate the image registry:
+If using GKE, you can populate the image registry using the command below:
 
-```
+```bash
 REGISTRY=gcr.io/$(gcloud config list --format 'value(core.project)')
+```
+
+If using Minikube, please run the command below to instruct Minikube to [use local Docker images](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon):
+```bash
+eval $(minikube docker-env)
 ```
 
 ### Get the Tutorial template

--- a/site/content/en/docs/Tutorials/Matchmaker101/deploy.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/deploy.md
@@ -17,9 +17,6 @@ sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchmaker.yaml | kubectl apply -f -
 
 - For Minikube users, run:
 ```
-# Instructs Minikube to use local images
-# https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon
-eval $(minikube docker-env)
 sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchmaker.yaml | sed "s|Always|Never|g" | kubectl apply -f -
 ```
 

--- a/site/content/en/docs/Tutorials/Matchmaker101/director.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/director.md
@@ -65,7 +65,7 @@ Now that you have customized the Director, please run the below commands from `$
 
 ```
 # Build the Director image.
-docker build -t $REGISTRY/mm101-tutorial-director director/.
+docker build -t $REGISTRY/mm101-tutorial-director director/
 
 # Push the Director image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-director

--- a/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/frontend.md
@@ -56,7 +56,7 @@ Now that you have customized the Game Frontend, please run the below commands fr
 
 ```
 # Build the Frontend image.
-docker build -t $REGISTRY/mm101-tutorial-frontend frontend/.
+docker build -t $REGISTRY/mm101-tutorial-frontend frontend/
 
 # Push the Frontend image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-frontend

--- a/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
@@ -76,7 +76,7 @@ Now that you have customized the MatchFunction, please run the below commands fr
 
 ```
 # Build the MatchFunction image.
-docker build -t $REGISTRY/mm101-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/mm101-tutorial-matchfunction matchfunction/
 
 # Push the MatchFunction image to the configured Registry.
 docker push $REGISTRY/mm101-tutorial-matchfunction

--- a/site/content/en/docs/Tutorials/Matchmaker102/_index.md
+++ b/site/content/en/docs/Tutorials/Matchmaker102/_index.md
@@ -31,6 +31,11 @@ If using GKE, you can populate the image registry using the command below:
 REGISTRY=gcr.io/$(gcloud config list --format 'value(core.project)')
 ```
 
+If using Minikube, please run the command below to instruct Minikube to [use local Docker images](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon):
+```bash
+eval $(minikube docker-env)
+```
+
 ### Get the Tutorial template
 
 Make a local copy of the [Tutorials Folder](https://github.com/googleforgames/open-match/blob/{{< param release_branch >}}/tutorials/matchmaker102). Use `tutorials/matchmaker102` as a working copy for all the instructions in this tutorial.
@@ -151,11 +156,11 @@ Although no changes are needed to the core matchmaking logic, you may add some l
 Now that you have customized these components, please run the below commands from `$TUTORIALROOT` to build new images and push them to your configured image registry.
 
 ```bash
-docker build -t $REGISTRY/mm102-tutorial-frontend frontend/.
+docker build -t $REGISTRY/mm102-tutorial-frontend frontend/
 docker push $REGISTRY/mm102-tutorial-frontend
-docker build -t $REGISTRY/mm102-tutorial-director director/.
+docker build -t $REGISTRY/mm102-tutorial-director director/
 docker push $REGISTRY/mm102-tutorial-director
-docker build -t $REGISTRY/mm102-tutorial-matchfunction matchfunction/.
+docker build -t $REGISTRY/mm102-tutorial-matchfunction matchfunction/
 docker push $REGISTRY/mm102-tutorial-matchfunction
 ```
 


### PR DESCRIPTION
It turns out that configure Minikube to use local docker images could be pretty tricky. It **requires** running the eval command **before** building the images and otherwise it won't work. This commit moved the Minikube configuration part to the `Prerequisite` section of each tutorial for better Minikube experience.