### PR TITLE
Remove mmlogic reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ tmp/
 # Open Match Binaries
 cmd/backend/backend
 cmd/frontend/frontend
-cmd/mmlogic/mmlogic
+cmd/query/query
 cmd/evaluator/evaluator
 cmd/minimatch/minimatch
 cmd/swaggerui/swaggerui

--- a/site/content/en/docs/Guides/Matchmaker/_index.md
+++ b/site/content/en/docs/Guides/Matchmaker/_index.md
@@ -31,9 +31,9 @@ template that can be used to generate matches) and returns matches for the reque
 It also provides the functionality for creating Assignments for Matches when invoked by the Director, and returning
 Assignments to the Open Match Frontend when requested.
 
-#### MMLogic (Data Service)
+#### Open Match QueryService (Data Service)
 
-The MMLogic service enables querying the Tickets that meet certain constraints from the current Ticket pool.
+The QueryService enables querying the Tickets that meet certain constraints from the current Ticket pool.
 
 ### Customized Components
 
@@ -41,7 +41,7 @@ To build a custom Matchmaker using Open Match, the user needs to provide the fol
 
 #### Match Function
 
-The core matchmaking logic is implemented as a Match Function service. Open Match Backend triggers the Match Function service when it receives a request to generate matches. The Match Function execution receives MatchProfiles, fetches Tickets that match the profile from MMLogic and returns matches.
+The core matchmaking logic is implemented as a Match Function service. Open Match Backend triggers the Match Function service when it receives a request to generate matches. The Match Function execution receives MatchProfiles, fetches Tickets that match the profile from QueryService and returns matches.
 
 #### Evaluator (Optional)
 
@@ -83,7 +83,7 @@ Now the Ticket representing this player is a part of a Ticket Pool actively bein
 
 1. The Director periodically calls FetchMatches on Open Match Backend to generate Matches for a MatchProfile.
 2. Open Match Backend triggers MatchFunction execution for this MatchProfile.
-3. The MatchFunction fetches all the Tickets from the active matchmaking Pool that match the filters in the the MatchProfile from Open Match Data Access API (MMLogic)
+3. The MatchFunction fetches all the Tickets from the active matchmaking Pool that match the filters in the the MatchProfile from Open Match QueryService API.
 4. The MatchFunction generates a Match using a subset of the queried Tickets.
 5. The Open Match Backend returns this Match to the Director.
 

--- a/site/content/en/docs/Guides/Matchmaker/_index.md
+++ b/site/content/en/docs/Guides/Matchmaker/_index.md
@@ -31,7 +31,7 @@ template that can be used to generate matches) and returns matches for the reque
 It also provides the functionality for creating Assignments for Matches when invoked by the Director, and returning
 Assignments to the Open Match Frontend when requested.
 
-#### Open Match QueryService (Data Service)
+#### Open Match QueryService
 
 The QueryService enables querying the Tickets that meet certain constraints from the current Ticket pool.
 

--- a/site/content/en/docs/Guides/Matchmaker/matchfunction.md
+++ b/site/content/en/docs/Guides/Matchmaker/matchfunction.md
@@ -42,7 +42,7 @@ The MatchProfile that the Match Function receives has a set of Pools specified. 
 ```
 rpc QueryTickets(QueryTicketsRequest) returns (stream QueryTicketsResponse) {
   option (google.api.http) = {
-    post: "/v1/mmlogic/tickets:query"
+    post: "/v1/queryservice/tickets:query"
     body: "*"
   };
 }

--- a/site/content/en/docs/Guides/Matchmaker/matchfunction.md
+++ b/site/content/en/docs/Guides/Matchmaker/matchfunction.md
@@ -37,7 +37,7 @@ This method is triggered at runtime whenever a FetchMatches call is received by 
 
 #### Query Tickets
 
-The MatchProfile that the Match Function receives has a set of Pools specified. Typically, the Match Function will call into Open Match to fetch all the Tickets belonging to each of the pools in the Match function. This can be done using the following API exposed by the Open Match MMLogic service:
+The MatchProfile that the Match Function receives has a set of Pools specified. Typically, the Match Function will call into Open Match to fetch all the Tickets belonging to each of the pools in the Match function. This can be done using the following API exposed by the Open Match QueryService:
 
 ```
 rpc QueryTickets(QueryTicketsRequest) returns (stream QueryTicketsResponse) {
@@ -51,7 +51,7 @@ rpc QueryTickets(QueryTicketsRequest) returns (stream QueryTicketsResponse) {
 Given that this functionality will be most commonly required for Match Functions, Open Match provides a golang library ("open-match.dev/open-match/pkg/matchfunction") to abstract this logic:
 
 ```
-func QueryPools(ctx context.Context, mml pb.MmLogicClient, pools []*pb.Pool) (map[string][]*pb.Ticket, error) {
+func QueryPools(ctx context.Context, mml pb.QueryServiceClient, pools []*pb.Pool) (map[string][]*pb.Ticket, error) {
 }
 ```
 

--- a/site/content/en/docs/Guides/api.md
+++ b/site/content/en/docs/Guides/api.md
@@ -19,8 +19,8 @@ The following defines the in-cluster hostnames and endpoints of Open Match's ext
 swaggerui:
   hostName: om-swaggerui
   httpPort: 51500
-mmlogic:
-  hostName: om-mmlogic
+query:
+  hostName: om-query
   grpcPort: 50503
   httpPort: 51503
 frontend:

--- a/site/content/en/docs/Guides/telemetry.md
+++ b/site/content/en/docs/Guides/telemetry.md
@@ -13,7 +13,6 @@ insight into the performance and health of your Open Match cluster. Currently, O
 * Prometheus
 * Grafana
 * Jaeger
-* Zipkin
 * Stackdriver
 
 ## Install telemetry backend 
@@ -29,8 +28,6 @@ kubectl apply -n open-match -f https://open-match.dev/install/v{{< param release
 kubectl apply -n open-match -f https://open-match.dev/install/v{{< param release_version >}}/yaml/05-jaeger-chart.yaml
 # Install the above telemetry backends with Open Match core services
 kubectl apply -n open-match -f https://open-match.dev/install/v{{< param release_version >}}/yaml/install.yaml
-# Install Zipkin:
-#   Zipkin's official get started guide (https://zipkin.io/pages/quickstart)
 # Install Stackdriver:
 #   No need to install, provided by GKE by default.
 ```
@@ -54,8 +51,6 @@ matchmaker_config_override.yaml:
     prometheus:
       enable: 'true'
     stackdriver:
-      enable: 'true'
-    zipkin:
       enable: 'true'
 ```
 

--- a/site/content/en/docs/Guides/tls.md
+++ b/site/content/en/docs/Guides/tls.md
@@ -82,7 +82,7 @@ openssl req -new -sha256 -key om-frontend.key -subj "/C=US/ST=Open/L=Match/O=Ope
 # of the server is specified by the Common Name (CN) parameter.
 #
 # The list of servers you'll want to generate keys for are:
-# om-backend:51505,om-demo:51507,om-demoevaluator:51508,om-demofunction:51502,om-e2eevaluator:51518,om-e2ematchfunction:51512,om-frontend:51504,om-mmlogic:51503,om-swaggerui:51500,om-synchronizer:51506
+# om-backend:51505,om-demo:51507,om-demoevaluator:51508,om-demofunction:51502,om-e2eevaluator:51518,om-e2ematchfunction:51512,om-frontend:51504,om-query:51503,om-swaggerui:51500,om-synchronizer:51506
 
 # Create a private key for the om-frontend server. (No password)
 openssl genrsa -out om-frontend.key 4096

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -69,7 +69,8 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 helm install --name my-release --namespace open-match open-match/open-match \
-  --set open-match-telemetry.enabled=true  --set open-match-telemetry.jaeger.enabled=true
+  --set open-match-telemetry.enabled=true  \
+  --set open-match-telemetry.jaeger.enabled=true
 ```
 
 The above command sets the namespace where Open Match is deployed to `open-match`. Additionally turn on the telemetry exporters and deploy Jaeger along with Open Match core services.
@@ -78,12 +79,12 @@ The following tables lists the configurable parameters of the Open Match chart a
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
-| `mmlogic.portType`                                | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the Mmlogic service                        | `ClusterIP`                 |
-| `mmlogic.replicas`                           | Defines the number of pod replicas for Mmlogic's Kubernetes deployment                                         | `3`                 |
-| `frontend.portType`                         | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the Frontend service                        | `ClusterIP`                               |                  |
-| `frontend.replicas`                    | Defines the number of pod replicas for Frontend's Kubernetes deployment                                         | `3`                 |
-| `backend.portType`                        | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the Backend service                        | `ClusterIP`                                         |                 |
-| `backend.replicas`                          | Defines the number of pod replicas for Backend's Kubernetes deployment                                                          | `3`        |
+| `query.portType`                                | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the QueryService                        | `ClusterIP`                 |
+| `query.replicas`                           | Defines the number of pod replicas for QueryService's Kubernetes deployment                                         | `3`                 |
+| `frontend.portType`                         | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the FrontendService                        | `ClusterIP`                               |                  |
+| `frontend.replicas`                    | Defines the number of pod replicas for FrontendService's Kubernetes deployment                                         | `3`                 |
+| `backend.portType`                        | Defines Kubernetes [ServiceTypes](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) for the BackendService                        | `ClusterIP`                                         |                 |
+| `backend.replicas`                          | Defines the number of pod replicas for BackendService's Kubernetes deployment                                                          | `3`        |
 | `image.pullPolicy`                               | Global `imagePullPolicy` for all Open Match service deployments | `Always` |
 | `image.tag`                       | Global Docker image tag for all Open Match service deployments |   `{{< param release_version >}}`       |
 | `open-match-core.enabled`         | Turn on/off the installation of Open Match core services                        | `true`                 |
@@ -107,10 +108,7 @@ The following tables lists the configurable parameters of the Open Match chart a
 | `global.telemetry.prometheus.endpoint` | Bind the Prometheus exporters to the specified endpoint handler, also configures the `prometheus.io/path` k8s scraping annotations                                    | `/metrics`                    |
 | `global.telemetry.prometheus.serviceDiscovery`       | If Prometheus is enabled and `serviceDiscover: true`, add the Prometheus scraping annotations to each Pod of the Open Match core services             | `true`                                  |
 | `global.telemetry.stackdriverMetrics.enabled`                       | Turn on/off Open Match Stackdriver Metrics exporter.                                                  | `false`                |
-| `global.telemetry.stackdriverMetrics.prefix`                       | MetricPrefix overrides the prefix of a Stackdriver metric display names to help you better identifies your metrics                                                  | `open_match`                |
-| `global.telemetry.zipkin.enabled`                            | Turn on/off Open Match Zipkin exporter.                                                                 | `false`          |
-| `global.telemetry.zipkin.endpoint`                            | Bind the Zipkin exporters to the specified endpoint handler                                                                 | `/zipkin`          |
-| `global.telemetry.zipkin.reporterEndpoint`                            | Overrides the Zipkin exporter endpoint                                                                 | `zipkin`          |
+| `global.telemetry.stackdriverMetrics.prefix`                       | MetricPrefix overrides the prefix of a Stackdriver metric display names to help you better identifies your metrics                                                  | `open_match`                |    |
 | `global.telemetry.grafana.enabled`                      | Turn on/off Open Match Grafana exporter. Also install Grafana if `open-match-telemetry.enabled` is set to true                                                          | `false`         |
 | `global.telemetry.reportingPeriod`                       | Overrides the reporting periods of Open Match telemetry exporters                                              | `1m`                 |
 | `open-match-telemetry.grafana`       | Inherits the values from [Grafana helm chart](https://github.com/helm/charts/tree/master/stable/grafana)                                               |                     |

--- a/site/content/en/docs/Installation/yaml.md
+++ b/site/content/en/docs/Installation/yaml.md
@@ -42,7 +42,7 @@ Output:
 NAME                                READY   STATUS              RESTARTS   AGE
 om-backend-76d8d76c96-fmhmn         0/1     ContainerCreating   0          3m53s
 om-frontend-57fc9f6b66-86hxj        0/1     ContainerCreating   0          3m53s
-om-mmlogic-799d8549d4-5qpgx         0/1     ContainerCreating   0          3m53s
+om-query-799d8549d4-5qpgx           0/1     ContainerCreating   0          3m53s
 om-swaggerui-867d79b885-m9q6x       0/1     ContainerCreating   0          3m54s
 om-synchronizer-7f48f84dfd-j8swx    0/1     ContainerCreating   0          3m54s
 ```

--- a/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
+++ b/site/content/en/docs/Tutorials/Matchmaker101/matchfunction.md
@@ -66,7 +66,7 @@ Please copy the above helper or add your own matchmaking logic to `$TUTORIALROOT
 
 The following values need to be changed if your setup is different from the default in the `$TUTORIALROOT/frontend/main.go`. The default value assumes you have Open Match deployed under `open-match` namespace and the Game Frontend under `mm101-tutorial` namespace in the same cluster:
 
-> `mmlogicAddress` - Open Match Mmlogic endpoint
+> `queryServiceAddress` - Open Match QueryService endpoint
 >
 > `serverPort` - Port Number that you host your Match Function service on, needs to be consistent with `functionPort` in the director. The current value uses the port specified in deployment YAML (covered later in the Deploy and Run step)
 

--- a/site/static/swaggerui/config.json
+++ b/site/static/swaggerui/config.json
@@ -2,7 +2,7 @@
     "urls": [
         {"name": "Frontend", "url": "https://open-match.dev/api/v0.0.0-dev/frontend.swagger.json"},
         {"name": "Backend", "url": "https://open-match.dev/api/v0.0.0-dev/backend.swagger.json"},
-        {"name": "Mmlogic", "url": "https://open-match.dev/api/v0.0.0-dev/mmlogic.swagger.json"},
+        {"name": "Query", "url": "https://open-match.dev/api/v0.0.0-dev/query.swagger.json"},
         {"name": "MatchFunction", "url": "https://open-match.dev/api/v0.0.0-dev/matchfunction.swagger.json"},
         {"name": "Synchronizer", "url": "https://open-match.dev/api/v0.0.0-dev/synchronizer.swagger.json"},
         {"name": "Evaluator", "url": "https://open-match.dev/api/v0.0.0-dev/evaluator.swagger.json"}


### PR DESCRIPTION
This commit removed references to mmlogic and use queryservice instead. Also removed references to zipkin since we removed the zipkin support in v0.9.