### PR TITLE
Disabled cloudbuild cacher to avoid build flakyness

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,8 +48,8 @@
 
 steps:
 - id: 'Docker Image: open-match-docs-build'
-  name: gcr.io/kaniko-project/executor
-  args: ['--destination=gcr.io/$PROJECT_ID/open-match-docs-build', '--cache=true', '--cache-ttl=48h', '--dockerfile=Dockerfile.ci']
+  name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/open-match-build', '-f', 'Dockerfile.ci', '.']
   waitFor: ['-']
 
 - id: 'Test: Markdown'

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -21,7 +21,7 @@
 				<a class="nav-link" href="{{ .Site.Params.github_code_repo }}">Github</a>
 			</li>
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				<a class="nav-link" href="{{.Site.BaseURL}}docs/reference/api">API</a>
+				<a class="nav-link" href="{{.Site.BaseURL}}docs/reference/api/">API</a>
 			</li>
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
 				<a class="nav-link" href="{{.Site.BaseURL}}swaggerui/index.html">SwaggerUI</a>


### PR DESCRIPTION
Kaniko cache introduced some level of flakyness and stucked our CI pipeline for half an hour during the release process. This commit disabled Kaniko cache in cloud build and use the regular Docker builder instead.