### PR TITLE
Point Redis Helm docs to Bitnami chart

### DIFF
--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -120,7 +120,7 @@ The following tables lists the configurable parameters of the Open Match chart a
 | `open-match-telemetry.grafana` | Inherits the values from [Grafana helm chart](https://github.com/helm/charts/tree/master/stable/grafana)  |  |
 | `open-match-telemetry.jaeger`  | Inherits the values from [Jaeger helm chart](https://github.com/helm/charts/tree/master/incubator/jaeger)  |  |
 | `open-match-telemetry.prometheus`  | Inherits the values from [Prometheus helm chart](https://github.com/helm/charts/tree/master/stable/prometheus) |  |
-| `redis` | Inherits the values from [Redis helm chart](https://github.com/helm/charts/tree/master/stable/redis) |  |
+| `redis` | Inherits the values from the [Bitnami Redis Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/redis) |  |
 
 ## What's Next
 


### PR DESCRIPTION
The documentation pointed at a deprecated Helm chart for Redis. This now points to the Bitnami Redis Helm chart, which is in use.