### PR TITLE
cluster machine type change

### DIFF
--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -38,7 +38,8 @@ gcloud services enable container.googleapis.com
 gcloud compute zones list
 
 # Create a GKE Cluster in this project
-gcloud container clusters create --machine-type n1-standard-2 open-match-cluster --zone us-west1-a --tags open-match
+gcloud container clusters create --machine-type n1-standard-4 \
+  --num-nodes=4 open-match-cluster --zone us-west1-a --tags open-match
 
 # Get kubectl credentials against GKE
 gcloud container clusters get-credentials open-match-cluster --zone us-west1-a


### PR DESCRIPTION
**What this PR does / Why we need it**:
Currently as we are seeing few github issues which talks about problems regarding data sync amongst the redis pods are as follows:
1. [There are multiple redis masters in v1.2.0-rc.1 #1374](https://github.com/googleforgames/open-match/issues/1374) 
 
2. [Tutorial: mm101-tutorial-frontend got "Failed to Get Ticket" errors #1418](https://github.com/googleforgames/open-match/issues/1418) 
 
One solution to counter above issues is upgrading  the redis helm chart used in OM and doing so requires the machine type `n1-standard-4` to provide the sufficient allocatable cpu and keeping the pre-existing values of resource request as it is.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes 

**Special notes for your reviewer**:
This PR is related with [Redis helm chart version change to 16.3.1 #1440](https://github.com/googleforgames/open-match/pull/1440)
