### PR TITLE
Fix wrong URL endpoint in Invoking Open Match APIs doc

### DIFF
--- a/site/content/en/docs/Guides/Api/_index.md
+++ b/site/content/en/docs/Guides/Api/_index.md
@@ -93,7 +93,7 @@ import (
 func main() {
   var m jsonpb.Marshaler
   // The HTTP endpoint of frontend.CreateTicket API
-  apiURL := fmt.Sprintf("http://om-frontend:%d/v1/frontend/tickets", 51504)
+  apiURL := fmt.Sprintf("http://om-frontend:%d/v1/frontendservice/tickets", 51504)
   // Create an Open Match CreateTicketRequest with Open Match's public package
   sent := &pb.CreateTicketRequest{
     Ticket: &pb.Ticket{


### PR DESCRIPTION
According to the latest [api/frontend.proto](https://github.com/googleforgames/open-match/blob/2b73d52e0cdc69a7cb435800a2226ed511f30f86/api/frontend.proto#L143), `/v1/frontendservice/` is used instead of `/v1/frontend/`.