### PR TITLE
enable production mode in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ node_modules/: build/toolchain/nodejs/
 $(RENDERED_SITE_DIR_REL)/: $(HUGO_REL) site/static/swaggerui/ node_modules/
 	rm -rf $(RENDERED_SITE_DIR)/
 	mkdir -p $(RENDERED_SITE_DIR)/
-	cd $(SITE_DIR) && $(HUGO) --config=config.toml --source . --destination $(RENDERED_SITE_DIR)/public/
+	cd $(SITE_DIR) && $(ENV) $(HUGO) --config=config.toml --source . --destination $(RENDERED_SITE_DIR)/public/
 	# Only copy the root directory since that has the AppEngine serving code.
 	-cp -f $(SITE_DIR)/* $(RENDERED_SITE_DIR)
 	-cp -f $(SITE_DIR)/.gcloudignore $(RENDERED_SITE_DIR)/.gcloudignore

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -96,7 +96,7 @@ steps:
 
 - id: 'Build: Website'
   name: 'gcr.io/$PROJECT_ID/open-match-docs-build'
-  args: ['make', 'BRANCH_NAME=${BRANCH_NAME}', 'build/site/']
+  args: ['make', 'BRANCH_NAME=${BRANCH_NAME}', 'build/site/', "ENV=HUGO_ENV=production"]
   waitFor: ['Lint: Format and Vet']
 
 - id: 'Test: Website'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**: This PR enables the production mode build by setting the environment variable `HUGO_ENV` so that the open-match.dev website can be recognised and/or indexed by search engines.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes [googleforgames/open-match/issues/1453
](https://github.com/googleforgames/open-match/issues/1453)

**Special notes for your reviewer**:


