### PR TITLE
Fix: Helm uninstall documentation to delete PVCs

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -48,7 +48,7 @@ Measure quality and latency of matches. Easily run experiments to find the right
 <div class="col">
 		<h2 class="text-center pb-3">Companies using Open Match</h2>
 		<p class="text-center showcase">
-			<a href="http://unity.com/"><img alt="unity" width="150" src="images/unity.png" /></a>
+			<a href="https://unity.com/"><img alt="unity" width="150" src="images/unity.png" /></a>
 		</p>
 </div>
 {{< /blocks/section >}}

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -59,7 +59,8 @@ helm install open-match --create-namespace --namespace open-match open-match/ope
 To uninstall/delete the `open-match` deployment:
 
 ```bash
-helm uninstall -n open-match open-match
+helm uninstall -n open-match open-match && \ 
+kubectl delete namespace open-match
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**: `open-match` requires `redis` to store the data and perform functional requirements on it. `Redis` is deployed via it's helm chart which creates **`PVCs`**. Helm command for uninstalling open-match release is not authorised to delete components created by another chart i.e. `redis`. So to fix this, we need to delete `open-match` namespace using `kubectl` command

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes [googleforgames/open-match/issues/1477](https://github.com/googleforgames/open-match/issues/1477)

**Special notes for your reviewer**: 
- Updated the url of unity.com because it was observed that cloud-build failed few times in other PR.


