### PR TITLE
Update golang runtime

### DIFF
--- a/site/app.yaml
+++ b/site/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go115
+runtime: go121
 service: development
 
 handlers:


### PR DESCRIPTION
go 1.15 support ends soon. https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule

Need to actually run a site deploy and make sure this doesn't break anything.